### PR TITLE
* add new practice exercise: reverse-string

### DIFF
--- a/config.json
+++ b/config.json
@@ -291,6 +291,14 @@
         "difficulty": 8
       },
       {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "cf1c3ed8-167a-47e8-af1a-2cc2d8403525",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 8
+      },
+      {
         "slug": "roman-numerals",
         "name": "Roman Numerals",
         "uuid": "f109325a-2bbb-46d7-a7ed-fe8484509985",

--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -1,0 +1,9 @@
+# Instructions
+
+Your task is to reverse a given string.
+
+Some examples:
+
+- Turn `"stressed"` into `"desserts"`.
+- Turn `"strops"` into `"sports"`.
+- Turn `"racecar"` into `"racecar"`.

--- a/exercises/practice/reverse-string/.docs/introduction.md
+++ b/exercises/practice/reverse-string/.docs/introduction.md
@@ -1,0 +1,5 @@
+# Introduction
+
+Reversing strings (reading them from right to left, rather than from left to right) is a surprisingly common task in programming.
+
+For example, in bioinformatics, reversing the sequence of DNA or RNA strings is often important for various analyses, such as finding complementary strands or identifying palindromic sequences that have biological significance.

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "jimmytty"
+  ],
+  "files": {
+    "solution": [
+      "reverse-string.sql"
+    ],
+    "test": [
+      "reverse-string_test.sql"
+    ],
+    "example": [
+      ".meta/example.sql"
+    ]
+  },
+  "blurb": "Reverse a given string.",
+  "source": "Introductory challenge to reverse an input string",
+  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
+}

--- a/exercises/practice/reverse-string/.meta/example.sql
+++ b/exercises/practice/reverse-string/.meta/example.sql
@@ -1,0 +1,12 @@
+UPDATE "reverse-string"
+   SET result = (
+     WITH RECURSIVE reverse_char(string, char) AS (
+       VALUES(input, '')
+       UNION ALL
+       SELECT SUBSTRING(string, 1, LENGTH(string) - 1),
+              SUBSTRING(string, -1)
+         FROM reverse_char
+        WHERE string <> ''
+     ) SELECT GROUP_CONCAT(char, '') FROM reverse_char
+);
+

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -40,3 +40,4 @@ comment = "skip unicode scenarios"
 [1028b2c1-6763-4459-8540-2da47ca512d9]
 description = "grapheme clusters"
 include = false
+comment = "skip unicode scenarios"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+include = false
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+include = false
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"
+include = false

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -35,6 +35,7 @@ comment = "skip unicode scenarios"
 [93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
 description = "grapheme cluster with pre-combined form"
 include = false
+comment = "skip unicode scenarios"
 
 [1028b2c1-6763-4459-8540-2da47ca512d9]
 description = "grapheme clusters"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -30,6 +30,7 @@ description = "an even-sized word"
 [1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
 description = "wide characters"
 include = false
+comment = "skip unicode scenarios"
 
 [93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
 description = "grapheme cluster with pre-combined form"

--- a/exercises/practice/reverse-string/create_fixture.sql
+++ b/exercises/practice/reverse-string/create_fixture.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS "reverse-string";
+CREATE TABLE "reverse-string" (
+    input  TEXT NOT NULL,
+    result TEXT
+);
+
+.mode csv
+.import ./data.csv reverse-string
+
+UPDATE "reverse-string" SET result = NULL;

--- a/exercises/practice/reverse-string/create_test_table.sql
+++ b/exercises/practice/reverse-string/create_test_table.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS tests;
+CREATE TABLE IF NOT EXISTS tests (
+    -- uuid and description are taken from the test.toml file
+    uuid TEXT PRIMARY KEY,
+    description TEXT NOT NULL,
+    -- The following section is needed by the online test-runner
+    status TEXT DEFAULT 'fail',
+    message TEXT,
+    output TEXT,
+    test_code TEXT,
+    task_id INTEGER DEFAULT NULL,
+    -- Here are columns for the actual tests
+    input    TEXT NOT NULL,
+    expected TEXT NOT NULL
+);
+
+INSERT INTO tests (uuid, description, input, expected)
+    VALUES
+        ('c3b7d806-dced-49ee-8543-933fd1719b1c','an empty string','',''),
+        ('01ebf55b-bebb-414e-9dec-06f7bb0bee3c','a word','robot','tobor'),
+        ('0f7c07e4-efd1-4aaa-a07a-90b49ce0b746','a capitalized word','Ramen','nemaR'),
+        ('71854b9c-f200-4469-9f5c-1e8e5eff5614','a sentence with punctuation','I''m hungry!','!yrgnuh m''I'),
+        ('1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c','a palindrome','racecar','racecar'),
+        ('b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c','an even-sized word','drawer','reward');

--- a/exercises/practice/reverse-string/data.csv
+++ b/exercises/practice/reverse-string/data.csv
@@ -1,0 +1,6 @@
+"",""
+"robot",""
+"Ramen",""
+"I'm hungry!",""
+"racecar",""
+"drawer",""

--- a/exercises/practice/reverse-string/reverse-string.sql
+++ b/exercises/practice/reverse-string/reverse-string.sql
@@ -1,0 +1,2 @@
+-- Schema: CREATE TABLE "reverse-string" (input TEXT NOT NULL, result TEXT);
+-- Task: update the reverse-string table and set the result based on the input.

--- a/exercises/practice/reverse-string/reverse-string_test.sql
+++ b/exercises/practice/reverse-string/reverse-string_test.sql
@@ -1,0 +1,40 @@
+-- Create database:
+.read ./create_fixture.sql
+
+-- Read user student solution and save any output as markdown in user_output.md:
+.mode markdown
+.output user_output.md
+.read ./reverse-string.sql
+.output
+
+-- Create a clean testing environment:
+.read ./create_test_table.sql
+
+-- Comparison of user input and the tests updates the status for each test:
+UPDATE tests
+SET status = 'pass'
+FROM (SELECT input, result FROM "reverse-string") AS actual
+WHERE (actual.input, actual.result) = (tests.input, tests.expected);
+
+-- Update message for failed tests to give helpful information:
+UPDATE tests
+SET message = (
+    'Result for "'
+    || tests.input
+    || '"'
+    || ' is <' || COALESCE(actual.result, 'NULL')
+    || '> but should be <' || tests.expected || '>'
+)
+FROM (SELECT input, result FROM "reverse-string") AS actual
+WHERE actual.input = tests.input AND tests.status = 'fail';
+
+-- Save results to ./output.json (needed by the online test-runner)
+.mode json
+.once './output.json'
+SELECT description, status, message, output, test_code, task_id
+FROM tests;
+
+-- Display test results in readable form for the student:
+.mode table
+SELECT description, status, message
+FROM tests;


### PR DESCRIPTION
I have removed the three unicode tests from [canonical-data.json](https://github.com/exercism/problem-specifications/blob/main/exercises/reverse-string/canonical-data.json) and set `include = false` in _tests.toml_ file.

The difficulty was set to 8 (hard).