### PR TITLE
Update install docs, bump alpine from 3.18 to 3.23 and sqlite from 3.41 to 3.51

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Target Version
 
-Testing for this track uses the `alpine:3.18` Docker image which, as of May 2025, uses `sqlite3 version 3.41.2`.
+Testing for this track uses the `alpine:3.23` Docker image which, as of May 2025, uses `sqlite3 version 3.51.2`.
 We strive to ensure that the tools provided by this track will work on the latest Ubuntu LTS release.
 While users may have newer versions installed, they should be aware that some features may not work with our test runner.
 Features can be compared on [SQLite version history][version-history].


### PR DESCRIPTION
This updates the docs to reflect the test runner change in https://github.com/exercism/sqlite-test-runner/pull/52

> Bump alpine from 3.18 to 3.23; this bumps sqlite from 3.41 to 3.51