### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# SQLite-specific instructions
+# Instructions append
+
+## SQLite-specific instructions
 
 To populate the `results` table, there are four "properties" you must consider:
 

--- a/exercises/practice/isogram/.docs/instructions.append.md
+++ b/exercises/practice/isogram/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Additional instructions
+# Instructions append
+
+## Additional instructions
 
 You will be provided a table named "isogram".
 The first column, "phrase", contains some text.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.